### PR TITLE
Add GitHub Actions workflow for Docker image build and push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,31 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/link-discord/website:latest


### PR DESCRIPTION
Add GitHub Actions workflow to build and push Docker image to GitHub Packages on push to main branch.

* Add `.github/workflows/docker-image.yml` file
* Trigger workflow on push to `main` branch
* Check out the repository
* Set up Docker Buildx
* Log in to GitHub Container Registry
* Build and push Docker image with tag `ghcr.io/link-discord/website:latest`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/link-discord/linkdiscord.xyz?shareId=a87e736c-e5ee-491a-9df9-c96ca2c09fcb).