### PR TITLE
Clear cache every hour for discord user data

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -32,6 +32,13 @@ async function fetchUser(id: any) {
 	return data
 }
 
+function clearCache() {
+	cache.userProfile = null
+	cache.friendProfiles = []
+}
+
+setInterval(clearCache, 3600000)
+
 export async function load() {
 	if (!cache.userProfile) {
 		cache.userProfile = await fetchUser(USER_ID)

--- a/src/routes/api/avatar/+server.ts
+++ b/src/routes/api/avatar/+server.ts
@@ -3,6 +3,12 @@ import { json } from '@sveltejs/kit'
 
 let cache: any = {}
 
+function clearCache() {
+	cache = {}
+}
+
+setInterval(clearCache, 3600000)
+
 export const GET = async ({ url }) => {
 	const id = String(url.searchParams.get('id'))
 


### PR DESCRIPTION
Add hourly cache clearing for discord user data.

* **src/routes/+layout.server.ts**
  - Add `clearCache` function to clear `userProfile` and `friendProfiles` in the `cache` object.
  - Use `setInterval` to call `clearCache` every hour.

* **src/routes/api/avatar/+server.ts**
  - Add `clearCache` function to clear the `cache` object.
  - Use `setInterval` to call `clearCache` every hour.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/link-discord/linkdiscord.xyz?shareId=5b5d5d8d-9fbd-4855-9695-f778c35238be).